### PR TITLE
Add function to set language for extensionless files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out
 node_modules
+.vscode-test

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=733558
+	// for the documentation about the tasks.json format
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "watch",
+			"problemMatcher": [],
+			"isBackground": true
+		}
+	]
+}

--- a/package.json
+++ b/package.json
@@ -30,5 +30,37 @@
 	},
 	"dependencies": {
 		"vscode-languageclient": "^5.2.1"
+	},
+	"contributes": {
+		"configuration": {
+			"type": "object",
+			"title": "Language Associator configuration",
+			"properties": {
+				"lua-ctrl-click.associations": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"title": "Patterns to match",
+						"properties": {
+							"pattern": {
+								"type": "string",
+								"description": "Pattern to test the first line."
+							},
+							"language": {
+								"type": "string",
+								"description": "Language to apply to matching files."
+							}
+						}
+					},
+					"default": [
+						{
+							"pattern": "^--lua$",
+							"language": "lua"
+						}
+					],
+					"description": "Automatically set the language of extensionless files by matching the first line (similar to checking a shebang '#!/bin/bash' but it can be any pattern)"
+				}
+			}
+		}
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,78 +11,156 @@ export function activate(context: vscode.ExtensionContext) {
 		return;
 	}
 
-	let sel: vscode.DocumentSelector = { scheme: 'file',language: 'lua' };
-    context.subscriptions.push(vscode.languages.registerDocumentLinkProvider(sel, new DocumentLinkProvider()));
+	let sel: vscode.DocumentSelector = { scheme: 'file', language: 'lua' };
+	context.subscriptions.push(
+		vscode.languages.registerDocumentLinkProvider(
+			sel,
+			new DocumentLinkProvider()
+		)
+	);
 
-	let fileSystemWatcher = vscode.workspace.createFileSystemWatcher('**/*.lua', false, true, false);
-	context.subscriptions.push(fileSystemWatcher.onDidCreate((filePath) => {
-		// console.log(filePath + " create!");
-		fileMap = readFileMap(basepath);
-	}));
-	context.subscriptions.push(fileSystemWatcher.onDidDelete((filePath) => {
-		// console.log(filePath + " delete!");
-		fileMap = readFileMap(basepath);
-	}));
+	let fileSystemWatcher = vscode.workspace.createFileSystemWatcher(
+		'**/*.lua',
+		false,
+		true,
+		false
+	);
+	context.subscriptions.push(
+		fileSystemWatcher.onDidCreate(filePath => {
+			// console.log(filePath + " create!");
+			fileMap = readFileMap(basepath);
+		})
+	);
+	context.subscriptions.push(
+		fileSystemWatcher.onDidDelete(filePath => {
+			// console.log(filePath + " delete!");
+			fileMap = readFileMap(basepath);
+		})
+	);
 
 	fileMap = readFileMap(basepath);
 
-}
+	// https://github.com/davidhewitt/shebang-language-associator/blob/master/src/extension.ts
 
+	/*
+	 * Any files open on startup need to have shebang checked.
+	 */
+	checkAllFiles();
+
+	/*
+	 * Re-check when configuration changes.
+	 */
+	let disposable = vscode.workspace.onDidChangeConfiguration(checkAllFiles);
+	context.subscriptions.push(disposable);
+
+	/*
+	 * And also when further files are opened we will check them.
+	 */
+	disposable = vscode.workspace.onDidOpenTextDocument(checkFile);
+	context.subscriptions.push(disposable);
+
+	disposable = vscode.workspace.onDidSaveTextDocument(checkFile);
+	context.subscriptions.push(disposable);
+}
 
 // this method is called when your extension is deactivated
 export function deactivate() {}
 
 function readFileMap(folder: string): {} {
-    let paths = {}
-    let files = fs.readdirSync(folder)
-    files.forEach(path => {
-        let fullPath = folder + "/" + path
-        if (!fs.lstatSync(fullPath).isDirectory()) {
-            paths[path] = fullPath
-        }
-        else if (path.substr(0, 1) != ".") {
-            let red = readFileMap(fullPath)
-            Object.keys(red).forEach(k => {
-                paths[k] = red[k]
-            })
-        }
-    });
-    return paths
+	let paths = {};
+	let files = fs.readdirSync(folder);
+	files.forEach(path => {
+		let fullPath = folder + '/' + path;
+		if (!fs.lstatSync(fullPath).isDirectory()) {
+			paths[path] = fullPath;
+		} else if (path.substr(0, 1) != '.') {
+			let red = readFileMap(fullPath);
+			Object.keys(red).forEach(k => {
+				paths[k] = red[k];
+			});
+		}
+	});
+	return paths;
 }
 
-
-var fileMap = {}
+var fileMap = {};
 let basepath = vscode.workspace.rootPath;
-let pattern = /(?:[\\s^\W])((?:[A-Z](?:[a-zA-Z]+))(?=[.:(]))+/g
+let pattern = /(?:[\\s^\W])((?:[A-Z](?:[a-zA-Z]+))(?=[.:(]))+/g;
 
 export class DocumentLinkProvider implements vscode.DocumentLinkProvider {
-
-
-	public provideDocumentLinks(doc: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.DocumentLink[]> {
+	public provideDocumentLinks(
+		doc: vscode.TextDocument,
+		token: vscode.CancellationToken
+	): vscode.ProviderResult<vscode.DocumentLink[]> {
 		let documentLinks: vscode.ProviderResult<vscode.DocumentLink[]> = [];
-        let line_idx = 0;
+		let line_idx = 0;
 
+		while (line_idx < doc.lineCount) {
+			let line = doc.lineAt(line_idx);
+			var result = pattern.exec(line.text);
+			while (result != null) {
+				let fileName = result[1] + '.lua';
+				let path = fileMap[fileName];
+				if (path != null && doc.fileName != path) {
+					let start =
+						result.index + (result[0].length - result[1].length);
+					let uri = vscode.Uri.file(path);
+					let range = new vscode.Range(
+						line_idx,
+						start,
+						line_idx,
+						start + result[1].length
+					);
+					let documentlink = new vscode.DocumentLink(
+						range,
+						uri.with({ fragment: result[1] })
+					);
+					documentLinks.push(documentlink);
+				}
 
-        while (line_idx < doc.lineCount) {
-            let line = doc.lineAt(line_idx);
-            var result = pattern.exec(line.text)
-            while (result != null) {
+				result = pattern.exec(line.text);
+			}
 
-                let fileName = result[1] + ".lua";
-                let path = fileMap[fileName]
-                if (path != null && doc.fileName != path) {
-                    let start = result.index + (result[0].length - result[1].length)
-                    let uri = vscode.Uri.file(path);
-                    let range = new vscode.Range(line_idx, start , line_idx, start + result[1].length );
-                    let documentlink = new vscode.DocumentLink(range, uri.with({ fragment: result[1] }));
-                    documentLinks.push(documentlink);
-                }
-
-                result = pattern.exec(line.text)
-            }
-
-            line_idx++;
+			line_idx++;
 		}
-        return documentLinks;
+		return documentLinks;
+	}
+}
+
+/**
+ * Re-check all open files
+ */
+function checkAllFiles() {
+	for (const td of vscode.workspace.textDocuments) {
+		checkFile(td);
+	}
+}
+
+/**
+ * Check whether a file has a matching shebang, and apply the appropriate
+ * language mode if so.
+ */
+function checkFile(doc: vscode.TextDocument) {
+	let shebang = doc.lineAt(0);
+
+	// skip files with extensions
+	if (!/^[^.]+$/.test(paths.basename(doc.fileName))) {
+		return;
+	}
+
+	let associations = vscode.workspace
+		.getConfiguration('lua-ctrl-click')
+		.get<Array<any>>('associations');
+
+	if (associations) {
+		for (const association of associations) {
+			if (shebang.text.match(new RegExp(association.pattern))) {
+				vscode.languages.setTextDocumentLanguage(
+					doc,
+					association.language
+				);
+				break;
+			}
+		}
 	}
 }


### PR DESCRIPTION
Copied and modified from davidhewitt.shebang-language-associator

adds a config setting `lua-ctrl-click.associations`

```json
"lua-ctrl-click.associations": [
	{
		"pattern": "^--lua$",
		"language": "lua"
	}
]
```

When a file with no extension (specifically `/^[^.]+$/`) is opened or saved, the first line is tested against the pattern, if it matches the pattern, the language is set as configured.